### PR TITLE
fix: Profile view is properly centered

### DIFF
--- a/frontend/src/custom.scss
+++ b/frontend/src/custom.scss
@@ -55,7 +55,3 @@ body {
   display: -webkit-box;
   -webkit-box-orient: vertical;
 }
-
-.user-info {
-  min-width: 800px;
-}


### PR DESCRIPTION
# Description

- Removed `min-width` to properly center the profile view in responsive view.